### PR TITLE
Add Gemini API function and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -839,6 +839,34 @@
         .btn-warning {
             background: linear-gradient(45deg, #ffc107, #fd7e14);
         }
+
+        /* Boîte Gemini */
+        .gemini-box {
+            margin-top: 20px;
+            text-align: center;
+        }
+
+        .gemini-input {
+            width: 100%;
+            max-width: 400px;
+            padding: 10px;
+            border-radius: 8px;
+            border: 1px solid #ccc;
+            background: rgba(255, 255, 255, 0.8);
+            margin-bottom: 10px;
+        }
+
+        .dark .gemini-input {
+            background: rgba(0, 0, 0, 0.6);
+            border-color: #555;
+            color: #fff;
+        }
+
+        .gemini-response {
+            margin-top: 10px;
+            white-space: pre-wrap;
+            font-size: 14px;
+        }
     </style>
 </head>
 <body>
@@ -930,6 +958,11 @@
                 <button class="btn" onclick="showLoadMenu()">📂 Charger</button>
                 <button class="btn" onclick="resetGame()">🔄 Nouveau jeu</button>
             </div>
+        </div>
+        <div id="geminiBox" class="gemini-box">
+            <input id="geminiInput" class="gemini-input" type="text" placeholder="Demandez à Gemini…">
+            <button id="geminiBtn" class="btn">Envoyer à Gemini</button>
+            <div id="geminiResponse" class="gemini-response"></div>
         </div>
     </div>
 
@@ -3754,11 +3787,46 @@
             }, 30000); // 30 secondes
         }
 
+        // Interroger l'API Gemini
+        async function askGemini(promptText) {
+            const endpoint = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=AIzaSyAexxa_34YRVsyqS9wUqKqoe_suqEXR7vE';
+            try {
+                const response = await fetch(endpoint, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        contents: [{ role: 'user', parts: [{ text: promptText }] }]
+                    })
+                });
+
+                if (!response.ok) throw new Error(response.statusText);
+                const data = await response.json();
+                return data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+            } catch (err) {
+                console.error('Gemini request failed:', err);
+                return '';
+            }
+        }
+
+        // Initialiser la boîte Gemini
+        function initGeminiBox() {
+            const btn = document.getElementById('geminiBtn');
+            if (!btn) return;
+            btn.addEventListener('click', async () => {
+                const input = document.getElementById('geminiInput');
+                const prompt = input.value.trim();
+                if (!prompt) return;
+                const result = await askGemini(prompt);
+                document.getElementById('geminiResponse').textContent = result;
+            });
+        }
+
         // Initialisation au chargement de la page
         window.onload = function() {
             initGame();
             initTheme();
             startAutoSave();
+            initGeminiBox();
         };
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add Gemini query box styled for dark mode
- style Gemini box input and output
- implement `askGemini` function to call Gemini API
- display Gemini output below prompt

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ce6a3723883248fc96fded27bec8a